### PR TITLE
Dockerize frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@
 
 **/.classpath
 **/.dockerignore
-**/.env
 **/.git
 **/.gitignore
 **/.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:23-alpine
+
+WORKDIR /usr/src/app
+
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    npm ci
+
+COPY . .
+
+EXPOSE 8000
+
+# uncomment this after fixing frontend routes
+# RUN npm run build
+# CMD npm run start
+
+CMD npm run dev


### PR DESCRIPTION
Dockerize frontend

compose.yaml look something like this:

```yaml
services:
  backend:
    build: ./cnit-academy-api
    ports:
      - 3000:3000
  frontend:
    build: ./cnit-academy-ui
    ports:
      - 8000:8000
```

Currently this runs the development build because of conflicting pages in (global_nav).